### PR TITLE
Add repo2docker-action appendix.

### DIFF
--- a/.github/workflows/build-push-image-commit.yaml
+++ b/.github/workflows/build-push-image-commit.yaml
@@ -58,7 +58,7 @@ jobs:
           # so all contents put in /home/jovyan are lost. This particularly prevents any 'start' script from
           # working, as it is needed in runtime.
           REPO_DIR: /srv/repo
-          APPENDIX_FILE: Dockerfile.appendix
+          APPENDIX_FILE: /srv/repo/Dockerfile.appendix
 
       # Lets us monitor disks getting full as images get bigger over time
       - name: Show how much disk space is left

--- a/.github/workflows/build-push-image-commit.yaml
+++ b/.github/workflows/build-push-image-commit.yaml
@@ -58,6 +58,7 @@ jobs:
           # so all contents put in /home/jovyan are lost. This particularly prevents any 'start' script from
           # working, as it is needed in runtime.
           REPO_DIR: /srv/repo
+          APPENDIX_FILE: Dockerfile.appendix
 
       # Lets us monitor disks getting full as images get bigger over time
       - name: Show how much disk space is left

--- a/.github/workflows/build-push-image-commit.yaml
+++ b/.github/workflows/build-push-image-commit.yaml
@@ -58,7 +58,7 @@ jobs:
           # so all contents put in /home/jovyan are lost. This particularly prevents any 'start' script from
           # working, as it is needed in runtime.
           REPO_DIR: /srv/repo
-          APPENDIX_FILE: /srv/repo/Dockerfile.appendix
+          APPENDIX_FILE: Dockerfile.appendix
 
       # Lets us monitor disks getting full as images get bigger over time
       - name: Show how much disk space is left

--- a/.github/workflows/build-test-image.yaml
+++ b/.github/workflows/build-test-image.yaml
@@ -43,6 +43,7 @@ jobs:
           FORCE_REPO2DOCKER_VERSION: jupyter-repo2docker==2024.07.0
           REPO_DIR: /srv/repo
           NO_PUSH: true
+          APPENDIX_FILE: Dockerfile.appendix
 
       # Lets us monitor disks getting full as images get bigger over time
       - name: Show how much disk space is left

--- a/Dockerfile.appendix
+++ b/Dockerfile.appendix
@@ -1,0 +1,2 @@
+USER root
+RUN ls -ld /usr/local/bin/

--- a/Dockerfile.appendix
+++ b/Dockerfile.appendix
@@ -1,2 +1,11 @@
 USER root
-RUN ls -ld /usr/local/bin/
+
+# As requested in slack.
+# http://www.dcc.fc.up.pt/gtries/
+# https://github.com/ComplexNetworks-DCC-FCUP/gtrieScanner
+RUN wget -O /tmp/gtrieScanner.zip https://www.dcc.fc.up.pt/gtries/gtrieScanner_src_01.zip && \
+    unzip -d /tmp /tmp/gtrieScanner.zip && \
+    make -C /tmp/gtrieScanner_src_01 && \
+    install -o root -g root -m 0755 /tmp/gtrieScanner_src_01/gtrieScanner /usr/local/bin/
+
+USER $NB_USER

--- a/postBuild
+++ b/postBuild
@@ -5,15 +5,3 @@ set -e
 # installing chromium browser to enable webpdf conversion using nbconvert
 export PLAYWRIGHT_BROWSERS_PATH=${CONDA_DIR}
 playwright install chromium
-
-# As requested in slack.
-# http://www.dcc.fc.up.pt/gtries/
-# https://github.com/ComplexNetworks-DCC-FCUP/gtrieScanner
-cd /tmp
-wget https://www.dcc.fc.up.pt/gtries/gtrieScanner_src_01.zip
-unzip gtrieScanner_src_01.zip
-cd gtrieScanner_src_01
-make
-# CONDA_DIR is writable by our UID in postBuild. Ideally this would be
-# in /usr/local/bin/.
-install -m 0755 gtrieScanner ${CONDA_DIR}/bin/


### PR DESCRIPTION
I chose the filename `Dockerfile.appendix` to reinforce the fact that the file should contain Dockerfile commands. There is also a convention for people to use filenames of the form `Dockerfile.dev`, `Dockerfile.prod`, etc.